### PR TITLE
Improve performance of link transforms streaming protocol

### DIFF
--- a/src/meshcat_viz/__init__.py
+++ b/src/meshcat_viz/__init__.py
@@ -1,3 +1,4 @@
+from . import meshcat
 from .model import MeshcatModel
 from .model_builder import MeshcatModelBuilder
 from .world import MeshcatWorld

--- a/src/meshcat_viz/meshcat/__init__.py
+++ b/src/meshcat_viz/meshcat/__init__.py
@@ -1,0 +1,1 @@
+from . import commands, server, visualizer

--- a/src/meshcat_viz/meshcat/__main__.py
+++ b/src/meshcat_viz/meshcat/__main__.py
@@ -1,0 +1,49 @@
+from .server import MeshCatServer
+
+
+def main():
+    import argparse
+    import asyncio
+    import platform
+    import sys
+    import webbrowser
+
+    # Fix asyncio configuration on Windows for Python 3.8 and above.
+    # Workaround for https://github.com/tornadoweb/tornado/issues/2608
+    if sys.version_info >= (3, 8) and platform.system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+    parser = argparse.ArgumentParser(
+        description="Serve the MeshCat HTML files and listen for ZeroMQ commands"
+    )
+    parser.add_argument("--zmq-url", "-z", type=str, nargs="?", default=None)
+    parser.add_argument("--open", "-o", action="store_true")
+    parser.add_argument("--certfile", type=str, default=None)
+    parser.add_argument("--keyfile", type=str, default=None)
+    parser.add_argument(
+        "--ngrok_http_tunnel",
+        action="store_true",
+        help="""
+ngrok is a service for creating a public URL from your local machine, which
+is very useful if you would like to make your meshcat server public.""",
+    )
+    results = parser.parse_args()
+    bridge = MeshCatServer(
+        zmq_url=results.zmq_url,
+        certfile=results.certfile,
+        keyfile=results.keyfile,
+        ngrok_http_tunnel=results.ngrok_http_tunnel,
+    )
+    print("zmq_url={:s}".format(bridge.zmq_url))
+    print("web_url={:s}".format(bridge.web_url))
+    if results.open:
+        webbrowser.open(bridge.web_url, new=2)
+
+    try:
+        bridge.run()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/meshcat_viz/meshcat/commands.py
+++ b/src/meshcat_viz/meshcat/commands.py
@@ -1,0 +1,45 @@
+import dataclasses
+from typing import Sequence
+
+import meshcat.path
+import numpy as np
+import numpy.typing as npt
+import umsgpack
+from meshcat import commands
+
+
+@dataclasses.dataclass
+class SetTransforms:
+    def __init__(
+        self,
+        matrices: Sequence[npt.NDArray],
+        paths: Sequence[str],
+        visualizer_root_path: meshcat.path.Path,
+    ):
+
+        self.paths = paths
+        self.matrices = matrices
+        self.visualizer_root_path = visualizer_root_path
+
+        assert np.array(matrices).shape == (len(paths), 4, 4)
+
+    def multipart(self) -> Sequence:
+
+        tfs = [
+            commands.SetTransform(matrix=m, path=self.visualizer_root_path.append(p))
+            for (m, p) in zip(self.matrices, self.paths)
+        ]
+
+        cmd = b"set_transforms"
+        size = str(len(self.paths)).encode("utf-8")
+
+        multipart = [cmd, size]
+
+        for tf in tfs:
+            tf_lower = tf.lower()
+            multipart += [
+                tf_lower["path"].encode("utf-8"),
+                umsgpack.packb(tf_lower),
+            ]
+
+        return multipart

--- a/src/meshcat_viz/meshcat/server.py
+++ b/src/meshcat_viz/meshcat/server.py
@@ -1,0 +1,138 @@
+import atexit
+import os
+import subprocess
+import sys
+from typing import List, Sequence, Tuple
+
+from meshcat.servers.tree import find_node
+from meshcat.servers.zmqserver import ZMQWebSocketBridge, match_web_url, match_zmq_url
+
+
+class MeshCatServer(ZMQWebSocketBridge):
+    def __init__(
+        self,
+        zmq_url=None,
+        host="127.0.0.1",
+        port=None,
+        certfile=None,
+        keyfile=None,
+        ngrok_http_tunnel=False,
+    ):
+
+        super().__init__(
+            zmq_url=zmq_url,
+            host=host,
+            port=port,
+            certfile=certfile,
+            keyfile=keyfile,
+            ngrok_http_tunnel=ngrok_http_tunnel,
+        )
+
+    def handle_zmq(self, frames: Sequence[bytes]) -> None:
+
+        cmd = frames[0].decode("utf-8")
+
+        if cmd == "set_transforms":
+
+            try:
+                self.process_cmd_set_transforms(frames=frames)
+                self.zmq_socket.send(f"ok {cmd}".encode("utf-8"))
+                return
+
+            except Exception as e:
+                self.zmq_socket.send(f"error '{cmd}': {str(e)}".encode("utf-8"))
+                return
+
+        # Call the upstream method for processing default commands
+        super().handle_zmq(frames=frames)
+
+    def process_cmd_set_transforms(self, frames: Sequence[bytes]) -> None:
+
+        # We cannot use individual calls like: super().handle_zmq(frames=frames)
+        # since each of them would send back the ack message to the client.
+
+        # Get the number of transforms
+        size = int(frames[1].decode("utf-8"))
+
+        # Make sure that the number of frames containing the command is correct
+        if len(frames[2:]) != 2 * size:
+            msg = f"error: expected {2 * size} frames"
+            raise ValueError(msg)
+
+        # Get the serialization of multiple SetTransform fields.
+        # See the "meshcat_viz.meshcat.commands.SetTransforms" class for more details.
+        set_transform_frames = frames[2:]
+
+        # Get the node path and binary representation of the full SetTransform object
+        paths = set_transform_frames[0::2]
+        set_transform_lowered_cmds = set_transform_frames[1::2]
+
+        # Iterate through the fields
+        for path, set_transform_lowered in zip(paths, set_transform_lowered_cmds):
+
+            # Create a hierarchical list of the node's path
+            path_list = [p for p in path.decode("utf-8").split("/") if len(p) > 0]
+
+            # Update the transform
+            find_node(self.tree, path_list).transform = set_transform_lowered
+
+            # Forward to websockets (otherwise the visualization doesn't refresh)
+            super().forward_to_websockets(
+                frames=("set_transform", path, set_transform_lowered)
+            )
+
+    @staticmethod
+    def start_as_subprocess(
+        zmq_url: str = None, server_args: List[str] = ()
+    ) -> Tuple[subprocess.Popen, str, str]:
+
+        # This is almost a copy of:
+        #     meshcat.servers.zmqserver.start_zmq_server_as_subprocess
+        # We had to re-define it here since the upstream server is started in a
+        # different process, and monkey-patching it during runtime with the aim of
+        # adding a new ZMQ command is not possible.
+        # Therefore, we copied here the logic to start the server and this class
+        # inherits from upstream by just extending ZMQWebSocketBridge.handle_zmq().
+
+        # Need -u for unbuffered output: https://stackoverflow.com/a/25572491
+        args = [sys.executable, "-u", "-m", "meshcat_viz.meshcat"]
+        if zmq_url is not None:
+            args.append("--zmq-url")
+            args.append(zmq_url)
+        if server_args:
+            args.append(*server_args)
+        # Note: Pass PYTHONPATH to be robust to workflows like Google Colab,
+        # where meshcat might have been added directly via sys.path.append.
+        # Copy existing environmental variables as some of them might be needed
+        # e.g. on Windows SYSTEMROOT and PATH
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        # Use start_new_session if it's available. Without it, in jupyter the server
+        # goes down when we cancel execution of any cell in the notebook.
+        server_proc = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,
+        )
+        line = ""
+        while "zmq_url" not in line:
+            line = server_proc.stdout.readline().strip().decode("utf-8")
+            if server_proc.poll() is not None:
+                outs, errs = server_proc.communicate()
+                print(outs.decode("utf-8"))
+                print(errs.decode("utf-8"))
+                raise RuntimeError(
+                    "the meshcat server process exited prematurely with exit code "
+                    + str(server_proc.poll())
+                )
+        zmq_url = match_zmq_url(line)
+        web_url = match_web_url(server_proc.stdout.readline().strip().decode("utf-8"))
+
+        def cleanup(server_proc):
+            server_proc.kill()
+            server_proc.wait()
+
+        atexit.register(cleanup, server_proc)
+        return server_proc, zmq_url, web_url

--- a/src/meshcat_viz/meshcat/visualizer.py
+++ b/src/meshcat_viz/meshcat/visualizer.py
@@ -1,0 +1,33 @@
+from typing import Sequence
+
+import meshcat.visualizer
+import numpy.typing as npt
+
+from .commands import SetTransforms
+
+
+class MeshcatVisualizer(meshcat.visualizer.Visualizer):
+    def __init__(
+        self,
+        zmq_url: str = None,
+        window: meshcat.visualizer.ViewerWindow = None,
+        server_args: Sequence = (),
+    ):
+
+        super(MeshcatVisualizer, self).__init__(
+            zmq_url=zmq_url, window=window, server_args=server_args
+        )
+
+    def set_transforms(
+        self, matrices: Sequence[npt.NDArray], paths: Sequence[str]
+    ) -> None:
+
+        set_transforms_cmd = SetTransforms(
+            paths=paths, matrices=matrices, visualizer_root_path=self.path
+        )
+
+        self.window.zmq_socket.send_multipart(msg_parts=set_transforms_cmd.multipart())
+        rec: str = self.window.zmq_socket.recv().decode("utf-8")
+
+        if not rec.startswith("ok"):
+            raise RuntimeError(f"[set_transforms] {str}")

--- a/src/meshcat_viz/model.py
+++ b/src/meshcat_viz/model.py
@@ -7,14 +7,15 @@ import meshcat
 import numpy as np
 import numpy.typing as npt
 from jaxsim import logging
-from meshcat.visualizer import Visualizer
+
+from .meshcat.visualizer import MeshcatVisualizer
 
 
 @dataclasses.dataclass
 class MeshcatModel:
 
     name: str
-    visualizer: Visualizer = dataclasses.field(repr=False)
+    visualizer: MeshcatVisualizer = dataclasses.field(repr=False)
 
     NodeName = str
     LinkName = str
@@ -137,3 +138,10 @@ class MeshcatModel:
 
         # Update the node pose
         self.visualizer[node_name].set_transform(parent_H_node)
+
+    def set_link_transforms(
+        self, link_names: Sequence[str], transforms: Sequence[npt.NDArray]
+    ) -> None:
+
+        node_names = [self.link_to_node[l] for l in link_names]
+        self.visualizer.set_transforms(paths=node_names, matrices=transforms)

--- a/src/meshcat_viz/model_builder.py
+++ b/src/meshcat_viz/model_builder.py
@@ -9,9 +9,9 @@ import numpy as np
 import rod
 from jaxsim import logging
 from jaxsim.parsers.kinematic_graph import KinematicGraph
-from meshcat.visualizer import Visualizer
 from scipy.spatial.transform import Rotation as R
 
+from .meshcat.visualizer import MeshcatVisualizer
 from .model import MeshcatModel
 from .visual import VisualShapeData, VisualShapeType
 
@@ -19,7 +19,7 @@ from .visual import VisualShapeData, VisualShapeType
 class MeshcatModelBuilder(abc.ABC):
     @staticmethod
     def from_kinematic_graph(
-        visualizer: Visualizer,
+        visualizer: MeshcatVisualizer,
         kinematic_graph: KinematicGraph,
         rod_model: rod.Model,
         model_name: str = None,


### PR DESCRIPTION
| Model | Links | Pre | Post | Improvement |
| --- | :---: | :---: | :---: | :---: |
| [`panda`][panda] | 10 | 17.3 ms ± 1.02 ms | 4.92 ms ± 300 µs | x3.5 |
| [`icub`][icub] | 33 | 50.7 ms ± 2.36 ms | 6.19 ms ± 260 µs | x8.2 |

[icub]: https://github.com/robotology/gym-ignition-models/tree/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/iCubGazeboV2_5
[panda]: https://github.com/robotology/gym-ignition-models/tree/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/panda

<details>
<summary>Testing script</summary>

```python
import pathlib

import gym_ignition_models
import numpy as np

from meshcat_viz.world import MeshcatWorld

if __name__ == "__main__":

    model_sdf_path = pathlib.Path(
        gym_ignition_models.get_model_resource(
            # robot_name="iCubGazeboV2_5",
            robot_name="panda",
            resource_type=gym_ignition_models.ResourceType.SDF_PATH,
        )
    )

    # Open the visualizer
    world = MeshcatWorld()
    world.open()

    # Insert the model from a URDF/SDF resource.
    # Note: for URDF files support, check details in https://github.com/ami-iit/rod.
    model_name = world.insert_model(sdf=model_sdf_path)

    # Update the joint positions
    s = world._jaxsim_models[model_name].joint_random_positions()
    world.update_model(model_name=model_name, joint_positions=s)

    %timeit -r10 -n25 world.update_model(model_name=model_name, joint_positions=s)
```

</details>

Visualization in real-time has visually good performance in the range 30-60 fps (33 ms and 16 ms, respectively).
With this PR, also models with a lot of DoFs are compatible with such rate.