### PR TITLE
Add support of heightmap to model non-flat terrain

### DIFF
--- a/src/meshcat_viz/heightmap.py
+++ b/src/meshcat_viz/heightmap.py
@@ -88,7 +88,10 @@ class Heightmap:
         # Create a temporary file with the PNG image...
         with tempfile.NamedTemporaryFile(mode="w+b", suffix=".png") as f:
             png.Writer(H, W, bitdepth=16, greyscale=True).write(
-                f, matrix_uint16.T.tolist()
+                f,
+                # Note that we have o flip the matrix over the y axis to match the
+                # convention used in meshcat
+                np.fliplr(matrix_uint16).T.tolist(),
             )
 
             f.seek(0)

--- a/src/meshcat_viz/heightmap.py
+++ b/src/meshcat_viz/heightmap.py
@@ -62,6 +62,9 @@ class Heightmap:
         # Get the range of the z axis
         z_range = self.z_bounds[1] - self.z_bounds[0]
 
+        # In the terrain is completely flat, z_range is zero
+        z_range = z_range if z_range > 0 else 1.0
+
         # Store the matrix normalized in [0, 1]
         self.matrix = np.array(
             (self.matrix - self.z_offset) / z_range,

--- a/src/meshcat_viz/heightmap.py
+++ b/src/meshcat_viz/heightmap.py
@@ -1,0 +1,121 @@
+import dataclasses
+import logging
+import tempfile
+from typing import Optional, Tuple
+
+import meshcat
+import numpy as np
+import numpy.typing as npt
+import png
+
+from . import logging
+
+
+@dataclasses.dataclass
+class Heightmap:
+    """"""
+
+    # This 2D matrix describes the (X, Y) -> Z terrain mapping.
+    # The matrix refers to the x-axis and y-axis ranges determined by the
+    # x_bounds and y_bounds attributes, discretized accordingly to the dimensions of
+    # the matrix.
+    matrix: npt.NDArray = dataclasses.field(kw_only=True)
+
+    x_bounds: Tuple[float, float] = dataclasses.field(default=(-0.5, 0.5))
+    y_bounds: Tuple[float, float] = dataclasses.field(default=(-0.5, 0.5))
+
+    z_offset: float = dataclasses.field(default=None)
+    z_bounds: Optional[Tuple[float, float]] = dataclasses.field(default=None)
+
+    def to_grid(self) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+        """"""
+
+        # Convert matrix from [0, 1] to [z_min, z_max]
+        Z = self.matrix * (self.z_bounds[1] - self.z_bounds[0]) + self.z_offset
+
+        # Create the x and y axes with absolute coordinates in [m], discretized
+        # accordingly to the matrix dimensions
+        x = np.linspace(self.x_bounds[0], self.x_bounds[1], self.matrix.shape[0])
+        y = np.linspace(self.y_bounds[0], self.y_bounds[1], self.matrix.shape[1])
+
+        # Create the X and Y matrices of the grid.
+        # We aim to obtain the equivalence, for a generic i/j indices:
+        # z = f(x[i], y[j]) = f(X[i, j], Y[i, j]) = Z[i, j].
+        Y, X = np.meshgrid(y, x)
+
+        return X, Y, Z
+
+    def __post_init__(self):
+        """"""
+
+        if self.matrix.ndim != 2:
+            raise ValueError(f"The matrix must be 2D (found {self.matrix.ndim} dims)")
+
+        # Infer the z offset from the input matrix
+        if self.z_offset is None:
+            self.z_offset = np.min(self.matrix)
+
+        # Infer the z bounds from the input matrix
+        if self.z_bounds is None:
+            self.z_bounds = (np.min(self.matrix), np.max(self.matrix))
+
+        # Get the range of the z axis
+        z_range = self.z_bounds[1] - self.z_bounds[0]
+
+        # Store the matrix normalized in [0, 1]
+        self.matrix = np.array(
+            (self.matrix - self.z_offset) / z_range,
+            dtype=np.float32,
+        )
+
+    def to_meshcat(self) -> meshcat.geometry.ImageTexture:
+        """Convert the matrix to ImageTexture compatible with MeshCat."""
+
+        # The stored matrix is already normalized in [0, 1]
+        matrix_01 = np.array(self.matrix, dtype=np.float32)
+
+        # Convert to uint16 with maximum range
+        matrix_uint16 = np.fmax(0, matrix_01 * 2**16 - 1).astype(np.uint16)
+
+        # Covert the XY axes to image height and width
+        H, W = matrix_01.shape
+
+        # Create a temporary file with the PNG image...
+        with tempfile.NamedTemporaryFile(mode="w+b", suffix=".png") as f:
+            png.Writer(H, W, bitdepth=16, greyscale=True).write(
+                f, matrix_uint16.T.tolist()
+            )
+
+            f.seek(0)
+            png_image = meshcat.geometry.PngImage.from_file(f.name)
+
+        # ... read by ImageTexture
+        return meshcat.geometry.ImageTexture(image=png_image)
+
+    def view(self) -> None:
+        """Render the matrix as 2D greyscale image."""
+
+        import matplotlib.image
+        import matplotlib.pyplot as plt
+
+        X, Y, Z = self.to_grid()
+
+        x = X[:, 0]
+        y = Y[0, :]
+
+        dx = (x[1] - x[0]) / 2.0
+        dy = (y[1] - y[0]) / 2.0
+        extent = [x[0] - dx, x[-1] + dx, y[0] - dy, y[-1] + dy]
+
+        fig, ax = plt.subplots(nrows=1, ncols=1)
+
+        img: matplotlib.image.AxesImage = ax.imshow(
+            Z.T, extent=extent, origin="lower", cmap="gray"
+        )
+
+        plt.colorbar(img)
+        ax.set_title("Heightmap")
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+
+        plt.show()

--- a/src/meshcat_viz/heightmap.py
+++ b/src/meshcat_viz/heightmap.py
@@ -71,6 +71,8 @@ class Heightmap:
             dtype=np.float32,
         )
 
+        assert not np.isnan(self.matrix).any()
+
     def to_meshcat(self) -> meshcat.geometry.ImageTexture:
         """Convert the matrix to ImageTexture compatible with MeshCat."""
 

--- a/src/meshcat_viz/meshcat/__init__.py
+++ b/src/meshcat_viz/meshcat/__init__.py
@@ -1,1 +1,1 @@
-from . import commands, server, visualizer
+from . import commands, geometry, material, server, visualizer

--- a/src/meshcat_viz/meshcat/__init__.py
+++ b/src/meshcat_viz/meshcat/__init__.py
@@ -1,1 +1,1 @@
-from . import commands, geometry, material, server, visualizer
+from . import commands, geometry, light, material, server, visualizer

--- a/src/meshcat_viz/meshcat/geometry.py
+++ b/src/meshcat_viz/meshcat/geometry.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from meshcat.geometry import Geometry
 
 
@@ -13,4 +15,29 @@ class Cone(Geometry):
             "type": "ConeGeometry",
             "radius": self.radius,
             "height": self.height,
+        }
+
+
+class PlaneGeometry(Geometry):
+    def __init__(
+        self,
+        width: float,
+        height: float,
+        widthSegments: Optional[int] = None,
+        heightSegments: Optional[int] = None,
+    ):
+        super(PlaneGeometry, self).__init__()
+        self.width = width
+        self.height = height
+        self.widthSegments = widthSegments if widthSegments is not None else width
+        self.heightSegments = heightSegments if heightSegments is not None else height
+
+    def lower(self, object_data):
+        return {
+            "uuid": self.uuid,
+            "type": "PlaneGeometry",
+            "width": self.width,
+            "height": self.height,
+            "widthSegments": self.widthSegments,
+            "heightSegments": self.heightSegments,
         }

--- a/src/meshcat_viz/meshcat/light.py
+++ b/src/meshcat_viz/meshcat/light.py
@@ -1,0 +1,93 @@
+from typing import Tuple
+
+import numpy as np
+from meshcat.geometry import Object
+
+
+class Light(Object):
+    """Generic light object."""
+
+    _type: str = None
+
+    def __init__(self, **kwargs):
+        super(Light, self).__init__(geometry=None, material=None)
+        self.properties = kwargs
+
+    def lower(self):
+        data = {
+            "metadata": {
+                "version": 4.5,
+                "type": "Object",
+            },
+            "object": {
+                "uuid": self.uuid,
+                "type": self._type,
+            },
+        }
+        data["object"].update(self.properties)
+        return data
+
+
+class HemisphereLight(Light):
+    _type = "HemisphereLight"
+
+    def __init__(
+        self,
+        sky_color: int = 0xFFFFFF,
+        ground_color: int = 0x444444,
+        intensity: float = 1.0,
+        position: Tuple[float, float, float] = (0, 0, 10.0),
+    ) -> None:
+        """"""
+
+        self.position = position
+
+        super(HemisphereLight, self).__init__(
+            skyColor=sky_color,
+            groundColor=ground_color,
+            intensity=np.pi * intensity,
+            position=list(position),
+            castShadow=False,
+        )
+
+
+class DirectionalLight(Light):
+    _type = "DirectionalLight"
+
+    def __init__(
+        self,
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        cast_shadow: bool = True,
+        position: Tuple[float, float, float] = (0.0, 0.0, 10.0),
+    ) -> None:
+        self.position = position
+
+        super(DirectionalLight, self).__init__(
+            color=color,
+            intensity=np.pi * intensity,
+            castShadow=cast_shadow,
+            position=list(position),
+        )
+
+
+class PointLight(Light):
+    _type = "PointLight"
+
+    def __init__(
+        self,
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        distance: float = 0.0,
+        decay: float = 2.0,
+        cast_shadow: bool = True,
+        position: Tuple[float, float, float] = (0.0, 0.0, 10.0),
+    ) -> None:
+        super(PointLight, self).__init__(
+            color=color,
+            intensity=np.pi * intensity,
+            distance=distance,
+            decay=decay,
+            castShadow=cast_shadow,
+            position=list(position),
+        )

--- a/src/meshcat_viz/meshcat/material.py
+++ b/src/meshcat_viz/meshcat/material.py
@@ -1,0 +1,74 @@
+from meshcat.geometry import ImageTexture, MeshPhongMaterial
+
+
+class HeightmapMaterial(MeshPhongMaterial):
+    def __init__(
+        self,
+        displacement_map: ImageTexture,
+        displacement_scale: float,
+        color=0xFFFFFF,
+        reflectivity=0.5,
+        map=None,
+        side=2,
+        transparent=None,
+        opacity=1.0,
+        linewidth=1.0,
+        wireframe=False,
+        wireframeLinewidth=1.0,
+        vertexColors=False,
+        **kwargs,
+    ):
+        self.displacementMap = displacement_map
+        self.displacementScale = displacement_scale
+
+        super().__init__(
+            color=color,
+            reflectivity=reflectivity,
+            map=map,
+            side=side,
+            transparent=transparent,
+            opacity=opacity,
+            linewidth=linewidth,
+            wireframe=wireframe,
+            wireframeLinewidth=wireframeLinewidth,
+            vertexColors=vertexColors,
+            **kwargs,
+        )
+
+    # Copy-paste from `GenericMaterial.lower`, adding support of displacement* elements
+    def lower(self, object_data):
+        # Three.js allows a material to have an opacity which is != 1,
+        # but to still be non-transparent, in which case the opacity only
+        # serves to desaturate the material's color. That's a pretty odd
+        # combination of things to want, so by default we juse use the
+        # opacity value to decide whether to set transparent to True or
+        # False.
+        if self.transparent is None:
+            transparent = bool(self.opacity != 1)
+        else:
+            transparent = self.transparent
+
+        data = {
+            "uuid": self.uuid,
+            "type": self._type,
+            "color": self.color,
+            "reflectivity": self.reflectivity,
+            "side": self.side,
+            "transparent": transparent,
+            "opacity": self.opacity,
+            "linewidth": self.linewidth,
+            "wireframe": bool(self.wireframe),
+            "wireframeLinewidth": self.wireframeLinewidth,
+            "vertexColors": (2 if self.vertexColors else 0),
+            "displacementScale": self.displacementScale,
+        }
+
+        data.update(self.properties)
+
+        if self.map is not None:
+            data["map"] = self.map.lower_in_object(object_data)
+
+        if self.displacementMap is not None:
+            data["displacementMap"] = self.displacementMap.lower_in_object(object_data)
+
+        return data

--- a/src/meshcat_viz/world.py
+++ b/src/meshcat_viz/world.py
@@ -17,7 +17,7 @@ from .model_builder import MeshcatModelBuilder
 class MeshcatWorld:
     """High-level class to manage a MeshCat scene."""
 
-    def __init__(self) -> None:
+    def __init__(self, draw_grid: bool = True) -> None:
         """Initialize a MeshCat world."""
 
         # The meshcat visualizer instance and the corresponding url
@@ -29,6 +29,9 @@ class MeshcatWorld:
 
         # All visualized models
         self._meshcat_models: Dict[str, MeshcatModel] = dict()
+
+        # Options
+        self.draw_grid = draw_grid
 
     def open(self) -> None:
         """Initialize the meshcat world by opening a visualizer."""
@@ -250,8 +253,10 @@ class MeshcatWorld:
         meshcat_visualizer = MeshcatVisualizer(zmq_url=zmq_url)
         meshcat_visualizer.window.server_proc = server_proc
 
+        # Draw the terrain grid
+        meshcat_visualizer["/Grid"].set_property("visible", self.draw_grid)
+
         # Configure the visualizer
-        meshcat_visualizer["/Grid"].set_property("visible", True)
         meshcat_visualizer["/Background"].set_property("visible", True)
         meshcat_visualizer["/Background"].set_property("top_color", [1, 1, 1])
         meshcat_visualizer["/Background"].set_property("bottom_color", [0, 0, 0])

--- a/src/meshcat_viz/world.py
+++ b/src/meshcat_viz/world.py
@@ -6,6 +6,8 @@ import numpy.typing as npt
 import rod
 from scipy.spatial.transform import Rotation
 
+from meshcat_viz.meshcat.light import HemisphereLight
+
 from . import logging
 from .fk.provider import FKProvider
 from .meshcat.server import MeshCatServer
@@ -260,6 +262,20 @@ class MeshcatWorld:
         meshcat_visualizer["/Background"].set_property("visible", True)
         meshcat_visualizer["/Background"].set_property("top_color", [1, 1, 1])
         meshcat_visualizer["/Background"].set_property("bottom_color", [0, 0, 0])
+
+        # Disable all the lights by default
+        meshcat_visualizer["/Lights/SpotLight"].set_property("visible", False)
+        meshcat_visualizer["/Lights/PointLightPositiveX"].set_property("visible", False)
+        meshcat_visualizer["/Lights/PointLightNegativeX"].set_property("visible", False)
+        meshcat_visualizer["/Lights/AmbientLight"].set_property("visible", False)
+        meshcat_visualizer["/Lights/FillLight"].set_property("visible", False)
+
+        # Enable only the PointLightNegativeX light
+        meshcat_visualizer["/Lights/PointLightNegativeX"].set_property("visible", True)
+
+        # Insert a Hemisphere light
+        light = HemisphereLight(position=(0, 0, 5.0), intensity=1 / np.pi)
+        meshcat_visualizer["/Lights/Hemisphere"].set_object(light)
 
         self._visualizer = meshcat_visualizer
         return self._visualizer


### PR DESCRIPTION
```python
import numpy as np
import rod.builder.primitives
import rod.urdf.exporter

from meshcat_viz import MeshcatWorld
from meshcat_viz.heightmap import Heightmap

cube_sdf = (
    rod.builder.primitives.BoxBuilder(x=0.1, y=0.2, z=0.3, mass=1.0, name="box")
    .build_model()
    .add_link("link")
    .add_inertial()
    .add_visual()
    .add_collision()
    .build()
)

sdf = rod.Sdf(model=cube_sdf, version="1.7")
urdf_string = rod.urdf.exporter.UrdfExporter.sdf_to_urdf_string(sdf=sdf, pretty=True)


# Open the visualizer
world = MeshcatWorld(draw_grid=False)
world.open()

# Insert the model from a URDF/SDF resource
model_name = world.insert_model(model_description=urdf_string, is_urdf=True)
# world.remove_model(model_name=model_name)

# Initialize the base position
world.update_model(
    model_name=model_name,
    base_position=np.array([0.2, 0, 0.2]),
)

# Create the x and y grids
X_grid = np.linspace(-2.0, 2.0, 256)
Y_grid = np.linspace(-2.0, 2.0, 256)
Y, X = np.meshgrid(Y_grid, X_grid)

# Smooth function modelling the terrain height
# https://www.sfu.ca/~ssurjano/drop.html
fn = lambda x, y: -(1 + np.cos(12 * np.sqrt(x**2 + y**2))) / (
    0.5 * (x**2 + y**2) + 2
)

# Compute the matrix representing the heightmap
Z = np.array([0.4 * fn(x, y) for x, y in zip(X.flatten(), Y.flatten())]).reshape(
    X.shape
)

# Create the heightmap object
heightmap = Heightmap(
    matrix=Z, x_bounds=(X_grid[0], X_grid[-1]), y_bounds=(Y_grid[0], Y_grid[-1])
)

# Insert the heightmap
world.insert_terrain_heightmap(heightmap=heightmap, enable_grid=True)

# This PR also adds the support of plotting a simple flat plane (before only the grid was displayed)
# world.insert_terrain_flat(enable_grid=True)
```

![Screenshot_20230718_175414](https://github.com/ami-iit/meshcat-viz-python/assets/469199/afd1e9f3-b058-47ed-9600-9899798f7071)

![Screenshot_20230718_180115](https://github.com/ami-iit/meshcat-viz-python/assets/469199/6bde48bc-5f67-462e-a7a4-54457712ee1d)
