### PR TITLE
Add missing `pypng` dependency used for heightmaps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     coloredlogs
     meshcat
     numpy
+    pypng
     rod
     scipy
 


### PR DESCRIPTION
Forgot to add this in #13.