### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ from meshcat_viz.world import MeshcatWorld
 # Load a model resource
 model_sdf_path = pathlib.Path(
     gym_ignition_models.get_model_resource(
-        robot_name="panda", resource_type=gym_ignition_models.ResourceType.SDF_PATH
+        robot_name="panda", resource_type=gym_ignition_models.ResourceType.URDF_PATH
     )
 )
 


### PR DESCRIPTION
It's worth mentioning that [ami-iit/rod](https://github.com/ami-iit/rod) needs to find some gazebo-related system dependencies to convert URDF to SDF.

Regardless, the example can run without any additional system dependency if the provided model description is already a SDF file.