### PR TITLE
Add Python 3.11 support for  `IDynTreeFKProvider`

### DIFF
--- a/src/meshcat_viz/fk/idyntree_provider.py
+++ b/src/meshcat_viz/fk/idyntree_provider.py
@@ -14,7 +14,9 @@ class IDynTreeFKProvider(FKProvider):
     urdf: dataclasses.InitVar[Union[str, pathlib.Path]]
     considered_joints: dataclasses.InitVar[List[str]]
 
-    base_pose: npt.NDArray = dataclasses.field(default=np.eye(4), init=False)
+    base_pose: npt.NDArray = dataclasses.field(
+        default_factory=lambda: np.eye(4), init=False
+    )
     joint_positions: Dict[str, float] = dataclasses.field(
         default_factory=dict, init=False
     )


### PR DESCRIPTION
With this PR, the support for Python 3.11 for the class `IDynTreeFKProvider` will be added.
According to [PEP 557](https://peps.python.org/pep-0557/#mutable-default-values), default fields in `dataclasses` must not be mutable ad `np.eye(4)` is a mutable `np.NDArray`, this falls in the following error:

> [!WARNING]
> **ValueError:** mutable default **<class 'numpy.ndarray'>** for field **base_pose** is not allowed: use **default_factory**

For this reason, the attribute `base_pose` has been set to a lambda.

C.C. @diegoferigo @traversaro 