### PR TITLE
Fix `resolve-robotics-uri-py` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ keywords =
     gui
     mesh
     meshcat
-    resolve_robotics_uri_py
     robot
     robotics
     sdf
@@ -57,6 +56,7 @@ install_requires =
     meshcat
     numpy
     pypng
+    resolve-robotics-uri-py
     rod
     scipy
 


### PR DESCRIPTION
This reverts https://github.com/ami-iit/meshcat-viz-python/pull/18/commits/5d51d0686d1cd399656956e79f534dcf19758f0b in which `resolve-robotics-uri-py` was put in the wrong section of the `setup.cfg`.